### PR TITLE
ci: name build job for branch‑protection status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,14 @@ on:
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:
-  permissions:
+
+permissions:
   contents: read
   security-events: write
 
 jobs:
   build:
+    name: build
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Adds an explicit job name (`name: build`) to ci.yml, ensuring that the GitHub Actions check registers as “CI / build” and can be selected as a required status check in the branch‑protection ruleset. Also moves the permissions block to the correct top‑level position. This change allows the ruleset to block merges until the CI workflow succeeds [oai_citation:0‡docs.github.com](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#:~:text=Status%20checks%20let%20you%20know,the%20repository%20you%27re%20contributing%20to).

## Summary
- What does this change do? Why is it needed?

## Related Issues / RFCs
- Closes #<issue-id> (if applicable)
- Links to design notes or RFCs (if any)

## Tests & Benchmarks
- [ ] Unit tests added/updated
- [ ] Baselines/benchmarks unchanged or improved
- Notes:

## AI Assist (provenance)
- AI used?  [ ] No  [ ] Yes — Tool: (Copilot/Claude/Other)
- If yes, briefly describe scope (e.g., docstrings, test scaffolding, boilerplate)

## Safety & Licensing
- [ ] No secrets or proprietary data included
- [ ] License headers & attributions checked
