### PR TITLE
docs: Bedrock owns Execution Copies; publish Engine API for Phoenix i…

### DIFF
--- a/docs/adr/0002-bedrock-owns-execution-copies.md
+++ b/docs/adr/0002-bedrock-owns-execution-copies.md
@@ -1,0 +1,16 @@
+# ADR 0002: Bedrock owns Execution Copies
+
+**Status:** Accepted  
+**Date:** 2025-10-03
+
+## Decision
+- Execution Copies (EC) are created from the canonical SOM snapshot and reside only in Bedrock.
+- API supports: `createExec`, `applyEdits`, `runAnalysis`, `commit`, `discard`.
+- `commit` promotes EC → canonical SOM and emits `SomChanged(version)` to Phoenix; `discard` drops it.
+- Cancellation tokens are checked between batches to keep the UI responsive.
+
+## Rationale
+Centralizing copy semantics and computation in Bedrock simplifies the UI and enforces consistent lifecycle and licensing.
+
+## Consequences
+- Bedrock must provide robust job and EC registries, progress, and error signaling.

--- a/docs/engine-api.md
+++ b/docs/engine-api.md
@@ -1,0 +1,27 @@
+# Bedrock Engine API (Stage 2)
+
+## Execution Copy lifecycle
+- `ExecId createExec(SomSnapshot base, SomDelta edits={})`
+- `void applyEdits(ExecId, SomDelta)`
+- `void commit(ExecId)` → promote to canonical SOM; emit `SomChanged(version)`
+- `void discard(ExecId)`
+
+## Analysis jobs
+- `JobId runAnalysis(ExecId, AnalysisSpec)`  // **async**
+- Signals:
+  - `Progress(JobId, percent)`  (throttled ~10–15 Hz)
+  - `Result(JobId, payload, meta)`
+  - `Error(JobId, code, reason)`
+- Cancellation tokens checked between batches.
+
+## Types
+- `SomSnapshot` and `SomDelta` come from Rosetta (proto-backed).
+- `AnalysisSpec` identifies a **Feature** and typed params.
+- `Result{meta, payload}`: payload is an opaque blob (FITS/HDF5/binary); meta provides small JSON for the UI.
+
+## Non-blocking guarantees
+- No blocking calls to Phoenix.
+- All callbacks delivered via queued connections (thread-safe).
+
+## Road to IPC
+Keep the API surface stable so the in-process engine can be swapped for an out‑of‑process service later (Qt Remote Objects/gRPC).


### PR DESCRIPTION
…ntegration

## Summary
- ADR 0002: EC lifecycle resides solely in Bedrock; commit/discard semantics; SomChanged event.
- Engine API definition: createExec/applyEdits/runAnalysis/commit/discard; progress/result/error signals; cancellation tokens.

## Why
Establishes the non-blocking contract for Phoenix and centralizes copy semantics + compute.

## Files
- README.md
- docs/adr/0002-bedrock-owns-execution-copies.md
- docs/engine-api.md

## Checks
- ✅ Build check should pass (docs-only)
- ℹ️ CodeQL present (not required)

## Summary
- What does this change do? Why is it needed?

## Related Issues / RFCs
- Closes #<issue-id> (if applicable)
- Links to design notes or RFCs (if any)

## Tests & Benchmarks
- [ ] Unit tests added/updated
- [ ] Baselines/benchmarks unchanged or improved
- Notes:

## AI Assist (provenance)
- AI used?  [ ] No  [ ] Yes — Tool: (Copilot/Claude/Other)
- If yes, briefly describe scope (e.g., docstrings, test scaffolding, boilerplate)

## Safety & Licensing
- [ ] No secrets or proprietary data included
- [ ] License headers & attributions checked
